### PR TITLE
Limit TURN virtual socket queue resources

### DIFF
--- a/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnServer.java
+++ b/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnServer.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
@@ -84,6 +85,9 @@ public final class TurnServer {
 
     static final Logger logger = Logger.getLogger(TurnServer.class.getName());
     private static final int DEFAULT_MAX_QUEUED_FRAMES = 2048;
+    private static final long DEFAULT_MAX_QUEUED_BYTES = 64L * 1024L * 1024L;
+    private static final int DEFAULT_MAX_VIRTUAL_SOCKETS = 1024;
+    private static final long DEFAULT_QUEUE_ITEM_TTL_MS = 30_000L;
     private static final String PEER_UNREACHABLE_REASON = "peer unreachable";
     private static final String UNAUTHENTICATED_TIMEOUT_REASON = "unauthenticated-timeout";
     private static final long SOCKET_LOOP_MS = 250L;
@@ -93,6 +97,7 @@ public final class TurnServer {
     final Map<TurnVirtualSocket.LogicalIdentity, SocketRef> logicalSockets =
         new ConcurrentHashMap<TurnVirtualSocket.LogicalIdentity, SocketRef>();
     final Map<TurnVirtualSocket, Session> socketOwners = new ConcurrentHashMap<TurnVirtualSocket, Session>();
+    private final AtomicLong queuedBytes = new AtomicLong(0L);
     private final Server jettyServer;
     private final TurnEventFactory eventFactory;
     final int difficulty;
@@ -100,6 +105,10 @@ public final class TurnServer {
     final int challengeTtlSeconds;
     final String host;
     private final int maxQueuedFrames;
+    private final long maxQueuedBytes;
+    private final int maxVirtualSockets;
+    private final long queueItemTtlMs;
+    private final TurnVirtualSocket.QueueBudget queueBudget;
     private final AsyncExecutor loopExecutor;
     private volatile boolean running = false;
 
@@ -260,6 +269,30 @@ public final class TurnServer {
         int challengeTtlSeconds,
         int maxQueuedFrames
     ) {
+        this(
+            host,
+            port,
+            serverSigner,
+            difficulty,
+            challengeTtlSeconds,
+            maxQueuedFrames,
+            DEFAULT_MAX_QUEUED_BYTES,
+            DEFAULT_MAX_VIRTUAL_SOCKETS,
+            DEFAULT_QUEUE_ITEM_TTL_MS
+        );
+    }
+
+    TurnServer(
+        String host,
+        int port,
+        NostrKeyPairSigner serverSigner,
+        int difficulty,
+        int challengeTtlSeconds,
+        int maxQueuedFrames,
+        long maxQueuedBytes,
+        int maxVirtualSockets,
+        long queueItemTtlMs
+    ) {
         // Validate constructor parameters early; these values shape server behavior.
         if (host == null || host.trim().isEmpty()) {
             throw new IllegalArgumentException("host must not be blank");
@@ -276,12 +309,35 @@ public final class TurnServer {
         if (maxQueuedFrames <= 0) {
             throw new IllegalArgumentException("maxQueuedFrames must be > 0");
         }
+        if (maxQueuedBytes <= 0L) {
+            throw new IllegalArgumentException("maxQueuedBytes must be > 0");
+        }
+        if (maxVirtualSockets <= 0) {
+            throw new IllegalArgumentException("maxVirtualSockets must be > 0");
+        }
+        if (queueItemTtlMs < 0L) {
+            throw new IllegalArgumentException("queueItemTtlMs must be >= 0");
+        }
         // Initialize signer/event factory and queue policy configuration.
         this.eventFactory = new TurnEventFactory(Objects.requireNonNull(serverSigner, "serverSigner cannot be null"));
         this.host = host.trim();
         this.difficulty = difficulty;
         this.challengeTtlSeconds = challengeTtlSeconds;
         this.maxQueuedFrames = maxQueuedFrames;
+        this.maxQueuedBytes = maxQueuedBytes;
+        this.maxVirtualSockets = maxVirtualSockets;
+        this.queueItemTtlMs = queueItemTtlMs;
+        this.queueBudget = new TurnVirtualSocket.QueueBudget() {
+            @Override
+            public boolean tryAcquire(int bytes) {
+                return reserveQueuedBytes(bytes);
+            }
+
+            @Override
+            public void release(int bytes) {
+                releaseQueuedBytes(bytes);
+            }
+        };
         this.loopExecutor = NGEUtils.getPlatform().newAsyncExecutor(TurnServer.class.getSimpleName() + "-loop");
 
         // Jetty bootstrap.
@@ -453,6 +509,11 @@ public final class TurnServer {
             closeConnection(connection.getWsSession(), "vsocket-collision");
             return;
         }
+        if (socketOwners.size() >= maxVirtualSockets && !logicalSockets.containsKey(incomingLogicalIdentity)) {
+            closeConnection(connection.getWsSession(), "too-many-virtual-sockets");
+            return;
+        }
+
         // Build accepted socket identity entry.
         TurnVirtualSocket senderSocket = new TurnVirtualSocket(
             vsocketId,
@@ -465,7 +526,9 @@ public final class TurnServer {
             applicationId,
             channelLabel,
             this::processQueuedFrame,
-            this::hasReachableRecipient
+            this::hasReachableRecipient,
+            queueBudget,
+            queueItemTtlMs
         );
 
         // Register accepted socket by websocket-local id and logical identity.
@@ -654,6 +717,35 @@ public final class TurnServer {
         // Notify sender and retire both sides from logical socket registries.
         sendFrame(senderSession, eventFactory.createDisconnect(senderSocket, reason, error), null, senderVsocketId);
         teardownSocket(senderSocket, reason, error, true, true);
+    }
+
+    private boolean reserveQueuedBytes(int bytes) {
+        if (bytes < 0) {
+            return false;
+        }
+        while (true) {
+            long current = queuedBytes.get();
+            long next = current + (long) bytes;
+            if (next < current || next > maxQueuedBytes) {
+                return false;
+            }
+            if (queuedBytes.compareAndSet(current, next)) {
+                return true;
+            }
+        }
+    }
+
+    private void releaseQueuedBytes(int bytes) {
+        if (bytes <= 0) {
+            return;
+        }
+        while (true) {
+            long current = queuedBytes.get();
+            long next = Math.max(0L, current - (long) bytes);
+            if (queuedBytes.compareAndSet(current, next)) {
+                return;
+            }
+        }
     }
 
     private SocketRef registerSocket(TurnClientConnection connection, TurnVirtualSocket socket) {

--- a/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnServer.java
+++ b/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnServer.java
@@ -327,17 +327,18 @@ public final class TurnServer {
         this.maxQueuedBytes = maxQueuedBytes;
         this.maxVirtualSockets = maxVirtualSockets;
         this.queueItemTtlMs = queueItemTtlMs;
-        this.queueBudget = new TurnVirtualSocket.QueueBudget() {
-            @Override
-            public boolean tryAcquire(int bytes) {
-                return reserveQueuedBytes(bytes);
-            }
+        this.queueBudget =
+            new TurnVirtualSocket.QueueBudget() {
+                @Override
+                public boolean tryAcquire(int bytes) {
+                    return reserveQueuedBytes(bytes);
+                }
 
-            @Override
-            public void release(int bytes) {
-                releaseQueuedBytes(bytes);
-            }
-        };
+                @Override
+                public void release(int bytes) {
+                    releaseQueuedBytes(bytes);
+                }
+            };
         this.loopExecutor = NGEUtils.getPlatform().newAsyncExecutor(TurnServer.class.getSimpleName() + "-loop");
 
         // Jetty bootstrap.

--- a/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnVirtualSocket.java
+++ b/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnVirtualSocket.java
@@ -33,6 +33,7 @@ package org.ngengine.nostr4j.turn.ref;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.Logger;
@@ -61,6 +62,22 @@ final class TurnVirtualSocket implements AutoCloseable {
 
     private static final Logger logger = Logger.getLogger(TurnVirtualSocket.class.getName());
     private static final int PRIORITY_RESERVED_SLOTS = 1;
+
+    interface QueueBudget {
+        boolean tryAcquire(int bytes);
+
+        void release(int bytes);
+    }
+
+    private static final QueueBudget NOOP_QUEUE_BUDGET = new QueueBudget() {
+        @Override
+        public boolean tryAcquire(int bytes) {
+            return true;
+        }
+
+        @Override
+        public void release(int bytes) {}
+    };
 
     static final class LogicalIdentity {
 
@@ -171,18 +188,32 @@ final class TurnVirtualSocket implements AutoCloseable {
     private final LogicalIdentity logicalIdentity;
     private final BlockingPacketQueue<QueuedOutgoingFrame> queuedPriorityOutgoingFrames;
     private final BlockingPacketQueue<QueuedOutgoingFrame> queuedOutgoingFrames;
+    private final QueueBudget queueBudget;
     private volatile boolean ackSent = false;
 
     static final class QueuedOutgoingFrame {
 
         private final byte[] frameBytes;
+        private final QueueBudget queueBudget;
+        private final AtomicBoolean released = new AtomicBoolean(false);
 
         private QueuedOutgoingFrame(byte[] frameBytes) {
+            this(frameBytes, NOOP_QUEUE_BUDGET);
+        }
+
+        private QueuedOutgoingFrame(byte[] frameBytes, QueueBudget queueBudget) {
             this.frameBytes = frameBytes;
+            this.queueBudget = queueBudget == null ? NOOP_QUEUE_BUDGET : queueBudget;
         }
 
         byte[] getFrameBytes() {
             return frameBytes;
+        }
+
+        void releaseBudget() {
+            if (released.compareAndSet(false, true)) {
+                queueBudget.release(frameBytes == null ? 0 : frameBytes.length);
+            }
         }
     }
 
@@ -199,6 +230,38 @@ final class TurnVirtualSocket implements AutoCloseable {
         BiFunction<TurnVirtualSocket, QueuedOutgoingFrame, AsyncTask<Boolean>> processQueuedFrame,
         Function<TurnVirtualSocket, Boolean> hasReachableRecipient
     ) {
+        this(
+            vsocketId,
+            roomPubkey,
+            clientPubkey,
+            targetPubkey,
+            sourceSessionId,
+            targetSessionId,
+            protocolId,
+            applicationId,
+            channelLabel,
+            processQueuedFrame,
+            hasReachableRecipient,
+            NOOP_QUEUE_BUDGET,
+            0L
+        );
+    }
+
+    TurnVirtualSocket(
+        long vsocketId,
+        NostrPublicKey roomPubkey,
+        NostrPublicKey clientPubkey,
+        NostrPublicKey targetPubkey,
+        String sourceSessionId,
+        String targetSessionId,
+        String protocolId,
+        String applicationId,
+        String channelLabel,
+        BiFunction<TurnVirtualSocket, QueuedOutgoingFrame, AsyncTask<Boolean>> processQueuedFrame,
+        Function<TurnVirtualSocket, Boolean> hasReachableRecipient,
+        QueueBudget queueBudget,
+        long queueItemTimeoutMs
+    ) {
         this.vsocketId = vsocketId;
         this.roomPubkey = roomPubkey;
         this.clientPubkey = clientPubkey;
@@ -208,6 +271,7 @@ final class TurnVirtualSocket implements AutoCloseable {
         this.protocolId = protocolId;
         this.applicationId = applicationId;
         this.channelLabel = channelLabel;
+        this.queueBudget = queueBudget == null ? NOOP_QUEUE_BUDGET : queueBudget;
         this.logicalIdentity =
             logicalIdentity(
                 roomPubkey,
@@ -224,7 +288,14 @@ final class TurnVirtualSocket implements AutoCloseable {
                 new BlockingPacketQueue.PacketHandler<TurnVirtualSocket.QueuedOutgoingFrame>() {
                     @Override
                     public AsyncTask<Boolean> handle(TurnVirtualSocket.QueuedOutgoingFrame frame) {
-                        return processQueuedFrame.apply(TurnVirtualSocket.this, frame);
+                        return processQueuedFrame
+                            .apply(TurnVirtualSocket.this, frame)
+                            .then(processed -> {
+                                if (Boolean.TRUE.equals(processed)) {
+                                    frame.releaseBudget();
+                                }
+                                return processed;
+                            });
                     }
 
                     @Override
@@ -233,14 +304,24 @@ final class TurnVirtualSocket implements AutoCloseable {
                     }
                 },
                 logger,
-                "TURN priority outgoing queue blocked"
+                "TURN priority outgoing queue blocked",
+                1000L,
+                6000L,
+                queueItemTimeoutMs
             );
         this.queuedOutgoingFrames =
             new BlockingPacketQueue<QueuedOutgoingFrame>(
                 new BlockingPacketQueue.PacketHandler<TurnVirtualSocket.QueuedOutgoingFrame>() {
                     @Override
                     public AsyncTask<Boolean> handle(TurnVirtualSocket.QueuedOutgoingFrame frame) {
-                        return processQueuedFrame.apply(TurnVirtualSocket.this, frame);
+                        return processQueuedFrame
+                            .apply(TurnVirtualSocket.this, frame)
+                            .then(processed -> {
+                                if (Boolean.TRUE.equals(processed)) {
+                                    frame.releaseBudget();
+                                }
+                                return processed;
+                            });
                     }
 
                     @Override
@@ -249,7 +330,10 @@ final class TurnVirtualSocket implements AutoCloseable {
                     }
                 },
                 logger,
-                "TURN outgoing queue blocked"
+                "TURN outgoing queue blocked",
+                1000L,
+                6000L,
+                queueItemTimeoutMs
             );
         // Do not drain any queued sender data before the connect ACK has been sent.
         this.queuedPriorityOutgoingFrames.stop();
@@ -293,6 +377,10 @@ final class TurnVirtualSocket implements AutoCloseable {
     }
 
     boolean enqueueOutgoing(byte[] frameBytes, int maxQueuedFrames, boolean priority) {
+        return enqueueOutgoing(frameBytes, maxQueuedFrames, priority, false);
+    }
+
+    private boolean enqueueOutgoing(byte[] frameBytes, int maxQueuedFrames, boolean priority, boolean budgetReserved) {
         int priorityQueued = this.queuedPriorityOutgoingFrames.size();
         int normalQueued = this.queuedOutgoingFrames.size();
         int totalQueued = priorityQueued + normalQueued;
@@ -313,7 +401,10 @@ final class TurnVirtualSocket implements AutoCloseable {
         BlockingPacketQueue<QueuedOutgoingFrame> queue = priority
             ? this.queuedPriorityOutgoingFrames
             : this.queuedOutgoingFrames;
-        queue.enqueue(new QueuedOutgoingFrame(frameBytes));
+        QueuedOutgoingFrame queuedFrame = budgetReserved
+            ? new QueuedOutgoingFrame(frameBytes, this.queueBudget)
+            : new QueuedOutgoingFrame(frameBytes);
+        queue.enqueue(queuedFrame, null, error -> queuedFrame.releaseBudget());
         return true;
     }
 
@@ -325,9 +416,23 @@ final class TurnVirtualSocket implements AutoCloseable {
         if (frame == null) {
             return false;
         }
-        byte[] frameBytes = new byte[frame.remaining()];
-        frame.asReadOnlyBuffer().get(frameBytes);
-        return enqueueOutgoing(frameBytes, maxQueuedFrames, priority);
+        int frameLength = frame.remaining();
+        if (!this.queueBudget.tryAcquire(frameLength)) {
+            return false;
+        }
+        byte[] frameBytes;
+        try {
+            frameBytes = new byte[frameLength];
+            frame.asReadOnlyBuffer().get(frameBytes);
+        } catch (RuntimeException | Error e) {
+            this.queueBudget.release(frameLength);
+            throw e;
+        }
+        if (!enqueueOutgoing(frameBytes, maxQueuedFrames, priority, true)) {
+            this.queueBudget.release(frameLength);
+            return false;
+        }
+        return true;
     }
 
     ByteBuffer in(QueuedOutgoingFrame queued, long recipientVsocketId) {

--- a/nostr4j-turn-server/src/test/java/org/ngengine/nostr4j/turn/ref/TestTurnServerInternalRegression.java
+++ b/nostr4j-turn-server/src/test/java/org/ngengine/nostr4j/turn/ref/TestTurnServerInternalRegression.java
@@ -15,6 +15,7 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.junit.Test;
@@ -155,6 +156,73 @@ public class TestTurnServerInternalRegression {
     }
 
     @Test
+    public void testQueueBudgetBoundsQueuedBytesAndReleasesOnClose() throws Exception {
+        ByteBuffer frame = encodedFrame("data", 501L, 301);
+        long frameBytes = frame.remaining();
+        AtomicLong queuedBytes = new AtomicLong(0L);
+        TurnVirtualSocket.QueueBudget budget = boundedBudget(queuedBytes, frameBytes);
+        TurnVirtualSocket sender = new TurnVirtualSocket(
+            501L,
+            new NostrKeyPair().getPublicKey(),
+            new NostrKeyPair().getPublicKey(),
+            new NostrKeyPair().getPublicKey(),
+            "sess-budget-a",
+            "sess-budget-b",
+            "proto",
+            "app",
+            "default",
+            (socket, queuedFrame) -> AsyncTask.completed(Boolean.FALSE),
+            socket -> Boolean.FALSE,
+            budget,
+            0L
+        );
+        try {
+            assertTrue(sender.out(encodedFrame("data", sender.getVsocketId(), 302), 16, false));
+            assertFalse(
+                "server-wide queued byte budget should reject additional retained frames",
+                sender.out(encodedFrame("data", sender.getVsocketId(), 303), 16, false)
+            );
+            assertTrue("queued bytes should be accounted while frame is retained", queuedBytes.get() > 0L);
+        } finally {
+            sender.close();
+        }
+        assertTrue("closing the socket should release queued byte accounting", queuedBytes.get() == 0L);
+    }
+
+    @Test
+    public void testQueueBudgetReleasesAfterSuccessfulDelivery() throws Exception {
+        ByteBuffer frame = encodedFrame("data", 551L, 351);
+        AtomicLong queuedBytes = new AtomicLong(0L);
+        TurnVirtualSocket.QueueBudget budget = boundedBudget(queuedBytes, frame.remaining());
+        AtomicInteger delivered = new AtomicInteger();
+        TurnVirtualSocket sender = new TurnVirtualSocket(
+            551L,
+            new NostrKeyPair().getPublicKey(),
+            new NostrKeyPair().getPublicKey(),
+            new NostrKeyPair().getPublicKey(),
+            "sess-deliver-a",
+            "sess-deliver-b",
+            "proto",
+            "app",
+            "default",
+            (socket, queuedFrame) -> {
+                delivered.incrementAndGet();
+                return AsyncTask.completed(Boolean.TRUE);
+            },
+            socket -> Boolean.TRUE,
+            budget,
+            0L
+        );
+        sender.markAckSent();
+        try {
+            assertTrue(sender.out(encodedFrame("data", sender.getVsocketId(), 352), 16, false));
+            waitUntil(() -> delivered.get() > 0 && queuedBytes.get() == 0L, 1000, "budget should release after delivery");
+        } finally {
+            sender.close();
+        }
+    }
+
+    @Test
     public void testPriorityQueueReservesCapacityWhenNormalBacklogIsFull() throws Exception {
         TurnVirtualSocket sender = new TurnVirtualSocket(
             451L,
@@ -229,6 +297,29 @@ public class TestTurnServerInternalRegression {
                 );
         method.setAccessible(true);
         return (AsyncTask<Boolean>) method.invoke(server, sender, queued);
+    }
+
+    private static TurnVirtualSocket.QueueBudget boundedBudget(AtomicLong queuedBytes, long maxBytes) {
+        return new TurnVirtualSocket.QueueBudget() {
+            @Override
+            public boolean tryAcquire(int bytes) {
+                while (true) {
+                    long current = queuedBytes.get();
+                    long next = current + (long) bytes;
+                    if (next > maxBytes) {
+                        return false;
+                    }
+                    if (queuedBytes.compareAndSet(current, next)) {
+                        return true;
+                    }
+                }
+            }
+
+            @Override
+            public void release(int bytes) {
+                queuedBytes.addAndGet(-bytes);
+            }
+        };
     }
 
     private static TurnVirtualSocket.QueuedOutgoingFrame queuedFrame(long vsocketId, int messageId) throws Exception {


### PR DESCRIPTION
### Motivation
- A previous change moved TURN frame queues to per-virtual-socket instances, leaving no server-wide limits and enabling an attacker to create many sockets and enqueue large (up to 1MiB) frames to exhaust memory and executor resources.\n
### Description
- Add server-wide resource budgets: a global queued-bytes cap (`maxQueuedBytes`), a maximum number of accepted virtual sockets (`maxVirtualSockets`), and an item TTL (`queueItemTtlMs`), with safe defaults and new constructor overloads in `TurnServer`.\n
- Introduce a `QueueBudget` interface and integrate a shared `queueBudget` into `TurnVirtualSocket` so bytes are *reserved* before copying the incoming frame and *released* when frames are delivered, rejected, or the socket is closed (accounting done via an `AtomicLong` in `TurnServer`).\n
- Enforce the virtual-socket cap at accept time and pass the shared `queueBudget` and `queueItemTtlMs` into each `TurnVirtualSocket`, and set the per-queue `queueItemTimeoutMs` on the `BlockingPacketQueue` instances to enable age-based eviction.\n
- Minimal, local API updates: `TurnVirtualSocket` gains an extra constructor accepting `QueueBudget` + TTL, and `TurnServer` has new internal helpers `reserveQueuedBytes` / `releaseQueuedBytes`.\n
- Add regression tests in `TestTurnServerInternalRegression` verifying that the queued-byte budget rejects additional retained frames and that accounting is released on close and after successful delivery.\n
Files changed: `TurnServer.java`, `TurnVirtualSocket.java`, `TestTurnServerInternalRegression.java`.\n
### Testing
- Ran the TURN-server unit tests: `./gradlew :nostr4j-turn-server:test --no-daemon` and the focused regression suite: `./gradlew :nostr4j-turn-server:test --tests org.ngengine.nostr4j.turn.ref.TestTurnServerInternalRegression --no-daemon`, both completed successfully (tests passed).\n
- Also ran `git diff --check` to ensure no whitespace or basic diff issues (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7bcf8a78832e82f114831653c04d)