### PR TITLE
Limit TURN server queued-frame memory by global byte budget

### DIFF
--- a/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnServer.java
+++ b/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnServer.java
@@ -536,7 +536,6 @@ public final class TurnServer {
         }
     }
 
-
     private boolean reserveQueuedBytes(long byteCount) {
         if (byteCount <= 0L) {
             return true;

--- a/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnServer.java
+++ b/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnServer.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
@@ -84,6 +85,7 @@ public final class TurnServer {
 
     static final Logger logger = Logger.getLogger(TurnServer.class.getName());
     private static final int DEFAULT_MAX_QUEUED_FRAMES = 2048;
+    private static final long DEFAULT_MAX_QUEUED_BYTES = 16L * 1024L * 1024L;
     private static final String PEER_UNREACHABLE_REASON = "peer unreachable";
     private static final String UNAUTHENTICATED_TIMEOUT_REASON = "unauthenticated-timeout";
     private static final long SOCKET_LOOP_MS = 250L;
@@ -100,6 +102,8 @@ public final class TurnServer {
     final int challengeTtlSeconds;
     final String host;
     private final int maxQueuedFrames;
+    private final long maxQueuedBytes;
+    private final AtomicLong queuedBytes = new AtomicLong(0L);
     private final AsyncExecutor loopExecutor;
     private volatile boolean running = false;
 
@@ -260,6 +264,18 @@ public final class TurnServer {
         int challengeTtlSeconds,
         int maxQueuedFrames
     ) {
+        this(host, port, serverSigner, difficulty, challengeTtlSeconds, maxQueuedFrames, DEFAULT_MAX_QUEUED_BYTES);
+    }
+
+    public TurnServer(
+        String host,
+        int port,
+        NostrKeyPairSigner serverSigner,
+        int difficulty,
+        int challengeTtlSeconds,
+        int maxQueuedFrames,
+        long maxQueuedBytes
+    ) {
         // Validate constructor parameters early; these values shape server behavior.
         if (host == null || host.trim().isEmpty()) {
             throw new IllegalArgumentException("host must not be blank");
@@ -276,12 +292,16 @@ public final class TurnServer {
         if (maxQueuedFrames <= 0) {
             throw new IllegalArgumentException("maxQueuedFrames must be > 0");
         }
+        if (maxQueuedBytes <= 0L) {
+            throw new IllegalArgumentException("maxQueuedBytes must be > 0");
+        }
         // Initialize signer/event factory and queue policy configuration.
         this.eventFactory = new TurnEventFactory(Objects.requireNonNull(serverSigner, "serverSigner cannot be null"));
         this.host = host.trim();
         this.difficulty = difficulty;
         this.challengeTtlSeconds = challengeTtlSeconds;
         this.maxQueuedFrames = maxQueuedFrames;
+        this.maxQueuedBytes = maxQueuedBytes;
         this.loopExecutor = NGEUtils.getPlatform().newAsyncExecutor(TurnServer.class.getSimpleName() + "-loop");
 
         // Jetty bootstrap.
@@ -505,9 +525,39 @@ public final class TurnServer {
         // delivery_ack frames use a priority queue so they are not starved by bulk data backlog.
         boolean prioritize = "delivery_ack".equals(TurnJson.safeString(header.getFirstTagFirstValue("t")));
         // Always enqueue to preserve per-socket ordering semantics within each class of traffic.
-        if (!senderSocket.out(fullFrame, maxQueuedFrames, prioritize)) {
+        int frameBytes = fullFrame.remaining();
+        if (!reserveQueuedBytes(frameBytes)) {
+            disconnectSenderSocket(connection.getWsSession(), senderSocket.getVsocketId(), PEER_UNREACHABLE_REASON, true);
+            return;
+        }
+        if (!senderSocket.out(fullFrame, maxQueuedFrames, prioritize, () -> releaseQueuedBytes(frameBytes))) {
+            releaseQueuedBytes(frameBytes);
             disconnectSenderSocket(connection.getWsSession(), senderSocket.getVsocketId(), PEER_UNREACHABLE_REASON, true);
         }
+    }
+
+
+    private boolean reserveQueuedBytes(long byteCount) {
+        if (byteCount <= 0L) {
+            return true;
+        }
+        while (true) {
+            long current = queuedBytes.get();
+            long updated = current + byteCount;
+            if (updated < current || updated > maxQueuedBytes) {
+                return false;
+            }
+            if (queuedBytes.compareAndSet(current, updated)) {
+                return true;
+            }
+        }
+    }
+
+    private void releaseQueuedBytes(long byteCount) {
+        if (byteCount <= 0L) {
+            return;
+        }
+        queuedBytes.updateAndGet(current -> Math.max(0L, current - byteCount));
     }
 
     private void sendAckForSocket(TurnClientConnection connection, TurnVirtualSocket socket) {

--- a/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnVirtualSocket.java
+++ b/nostr4j-turn-server/src/main/java/org/ngengine/nostr4j/turn/ref/TurnVirtualSocket.java
@@ -33,6 +33,7 @@ package org.ngengine.nostr4j.turn.ref;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.Logger;
@@ -176,13 +177,26 @@ final class TurnVirtualSocket implements AutoCloseable {
     static final class QueuedOutgoingFrame {
 
         private final byte[] frameBytes;
+        private final Runnable releaseCallback;
+        private final AtomicBoolean released = new AtomicBoolean(false);
 
         private QueuedOutgoingFrame(byte[] frameBytes) {
+            this(frameBytes, null);
+        }
+
+        private QueuedOutgoingFrame(byte[] frameBytes, Runnable releaseCallback) {
             this.frameBytes = frameBytes;
+            this.releaseCallback = releaseCallback;
         }
 
         byte[] getFrameBytes() {
             return frameBytes;
+        }
+
+        void release() {
+            if (releaseCallback != null && released.compareAndSet(false, true)) {
+                releaseCallback.run();
+            }
         }
     }
 
@@ -313,7 +327,34 @@ final class TurnVirtualSocket implements AutoCloseable {
         BlockingPacketQueue<QueuedOutgoingFrame> queue = priority
             ? this.queuedPriorityOutgoingFrames
             : this.queuedOutgoingFrames;
-        queue.enqueue(new QueuedOutgoingFrame(frameBytes));
+        QueuedOutgoingFrame queued = new QueuedOutgoingFrame(frameBytes, null);
+        queue.enqueue(queued);
+        return true;
+    }
+
+    boolean enqueueOutgoing(byte[] frameBytes, int maxQueuedFrames, boolean priority, Runnable releaseCallback) {
+        int priorityQueued = this.queuedPriorityOutgoingFrames.size();
+        int normalQueued = this.queuedOutgoingFrames.size();
+        int totalQueued = priorityQueued + normalQueued;
+
+        int reservedForPriority = maxQueuedFrames > 1 ? PRIORITY_RESERVED_SLOTS : 0;
+        int normalCapacity = Math.max(0, maxQueuedFrames - reservedForPriority);
+
+        if (priority) {
+            if (totalQueued >= maxQueuedFrames) {
+                return false;
+            }
+        } else {
+            if (normalQueued >= normalCapacity || totalQueued >= maxQueuedFrames) {
+                return false;
+            }
+        }
+
+        BlockingPacketQueue<QueuedOutgoingFrame> queue = priority
+            ? this.queuedPriorityOutgoingFrames
+            : this.queuedOutgoingFrames;
+        QueuedOutgoingFrame queued = new QueuedOutgoingFrame(frameBytes, releaseCallback);
+        queue.enqueue(queued, ignored -> queued.release(), error -> queued.release());
         return true;
     }
 
@@ -322,12 +363,16 @@ final class TurnVirtualSocket implements AutoCloseable {
     }
 
     boolean out(ByteBuffer frame, int maxQueuedFrames, boolean priority) {
+        return out(frame, maxQueuedFrames, priority, null);
+    }
+
+    boolean out(ByteBuffer frame, int maxQueuedFrames, boolean priority, Runnable releaseCallback) {
         if (frame == null) {
             return false;
         }
         byte[] frameBytes = new byte[frame.remaining()];
         frame.asReadOnlyBuffer().get(frameBytes);
-        return enqueueOutgoing(frameBytes, maxQueuedFrames, priority);
+        return enqueueOutgoing(frameBytes, maxQueuedFrames, priority, releaseCallback);
     }
 
     ByteBuffer in(QueuedOutgoingFrame queued, long recipientVsocketId) {

--- a/nostr4j-turn-server/src/test/java/org/ngengine/nostr4j/turn/ref/TestTurnServerInternalRegression.java
+++ b/nostr4j-turn-server/src/test/java/org/ngengine/nostr4j/turn/ref/TestTurnServerInternalRegression.java
@@ -111,7 +111,6 @@ public class TestTurnServerInternalRegression {
         assertTrue(NGEUtils.awaitNoThrow(invokeProcessQueuedFrame(server, sender, queued)).booleanValue());
     }
 
-
     @Test
     public void testQueuedFrameBytesAreGloballyBounded() throws Exception {
         NostrKeyPair room = new NostrKeyPair();
@@ -120,15 +119,7 @@ public class TestTurnServerInternalRegression {
         SignedNostrEvent header = signedHeader("data", senderKeys);
         ByteBuffer frame = encodedFrame(header, 501L, 301, new byte[64]);
         long maxQueuedBytes = frame.remaining();
-        TurnServer server = new TurnServer(
-            "127.0.0.1",
-            12347,
-            NostrKeyPairSigner.generate(),
-            8,
-            5,
-            32,
-            maxQueuedBytes
-        );
+        TurnServer server = new TurnServer("127.0.0.1", 12347, NostrKeyPairSigner.generate(), 8, 5, 32, maxQueuedBytes);
 
         TurnVirtualSocket sender = buildSocket(
             501L,
@@ -319,12 +310,7 @@ public class TestTurnServerInternalRegression {
     }
 
     private static ByteBuffer encodedFrame(SignedNostrEvent header, long vsocketId, int messageId) {
-        return NostrTURNCodec.encodeFrame(
-            NostrTURNCodec.encodeHeader(header),
-            vsocketId,
-            messageId,
-            Collections.emptyList()
-        );
+        return NostrTURNCodec.encodeFrame(NostrTURNCodec.encodeHeader(header), vsocketId, messageId, Collections.emptyList());
     }
 
     private static String frameType(TurnVirtualSocket.QueuedOutgoingFrame frame) {

--- a/nostr4j-turn-server/src/test/java/org/ngengine/nostr4j/turn/ref/TestTurnServerInternalRegression.java
+++ b/nostr4j-turn-server/src/test/java/org/ngengine/nostr4j/turn/ref/TestTurnServerInternalRegression.java
@@ -111,6 +111,53 @@ public class TestTurnServerInternalRegression {
         assertTrue(NGEUtils.awaitNoThrow(invokeProcessQueuedFrame(server, sender, queued)).booleanValue());
     }
 
+
+    @Test
+    public void testQueuedFrameBytesAreGloballyBounded() throws Exception {
+        NostrKeyPair room = new NostrKeyPair();
+        NostrKeyPair senderKeys = new NostrKeyPair();
+        NostrKeyPair receiverKeys = new NostrKeyPair();
+        SignedNostrEvent header = signedHeader("data", senderKeys);
+        ByteBuffer frame = encodedFrame(header, 501L, 301, new byte[64]);
+        long maxQueuedBytes = frame.remaining();
+        TurnServer server = new TurnServer(
+            "127.0.0.1",
+            12347,
+            NostrKeyPairSigner.generate(),
+            8,
+            5,
+            32,
+            maxQueuedBytes
+        );
+
+        TurnVirtualSocket sender = buildSocket(
+            501L,
+            room.getPublicKey(),
+            senderKeys.getPublicKey(),
+            receiverKeys.getPublicKey(),
+            "sess-byte-a",
+            "sess-byte-b"
+        );
+        Session senderSession = sessionProxy(SendBehavior.SUCCEED);
+        TurnClientConnection senderConnection = new TurnClientConnection(senderSession, 8);
+        senderConnection.getSockets().put(Long.valueOf(sender.getVsocketId()), sender);
+        server.clients.put(senderSession, senderConnection);
+        server.socketOwners.put(sender, senderSession);
+
+        try {
+            server.handleData(senderConnection, header, frame.asReadOnlyBuffer(), sender.getVsocketId());
+            assertTrue(senderConnection.getSockets().containsKey(Long.valueOf(sender.getVsocketId())));
+
+            server.handleData(senderConnection, header, frame.asReadOnlyBuffer(), sender.getVsocketId());
+            assertFalse(
+                "second queued frame should exceed the byte budget and disconnect sender socket",
+                senderConnection.getSockets().containsKey(Long.valueOf(sender.getVsocketId()))
+            );
+        } finally {
+            server.closeConnection(senderSession, "test-complete");
+        }
+    }
+
     @Test
     public void testPriorityDeliveryAckNotStarvedByBlockedDataQueue() throws Exception {
         AtomicInteger dataStarted = new AtomicInteger();
@@ -246,17 +293,34 @@ public class TestTurnServerInternalRegression {
     }
 
     private static SignedNostrEvent signedHeader(String type) {
+        return signedHeader(type, new NostrKeyPair());
+    }
+
+    private static SignedNostrEvent signedHeader(String type, NostrKeyPair keyPair) {
         UnsignedNostrEvent unsigned = new UnsignedNostrEvent()
             .withKind(25051)
             .createdAt(Instant.now())
             .withTag("t", type)
             .withContent("");
-        return NGEUtils.awaitNoThrow(NostrKeyPairSigner.generate().sign(unsigned));
+        return NGEUtils.awaitNoThrow(new NostrKeyPairSigner(keyPair).sign(unsigned));
     }
 
     private static ByteBuffer encodedFrame(String type, long vsocketId, int messageId) {
+        return encodedFrame(signedHeader(type), vsocketId, messageId);
+    }
+
+    private static ByteBuffer encodedFrame(SignedNostrEvent header, long vsocketId, int messageId, byte[] payload) {
         return NostrTURNCodec.encodeFrame(
-            NostrTURNCodec.encodeHeader(signedHeader(type)),
+            NostrTURNCodec.encodeHeader(header),
+            vsocketId,
+            messageId,
+            Collections.singletonList(payload)
+        );
+    }
+
+    private static ByteBuffer encodedFrame(SignedNostrEvent header, long vsocketId, int messageId) {
+        return NostrTURNCodec.encodeFrame(
+            NostrTURNCodec.encodeHeader(header),
             vsocketId,
             messageId,
             Collections.emptyList()


### PR DESCRIPTION
### Motivation
- Address a remote memory-exhaustion exposure where the TURN reference server queued whole incoming frames (up to 1 MiB each) and enforced only a frame-count limit, allowing a client to force large heap retention. 
- Add a lightweight, deterministic protection that preserves per-socket ordering and delivery semantics while preventing unbounded global memory growth.

### Description
- Introduce a global byte budget with `DEFAULT_MAX_QUEUED_BYTES` and atomic accounting via `queuedBytes` in `TurnServer`, plus constructor overloads to configure `maxQueuedBytes`. 
- On `handleData`, reserve the frame byte count before enqueueing and disconnect the sender if the global byte budget would be exceeded by using `reserveQueuedBytes(...)` and `releaseQueuedBytes(...)` helpers. 
- Extend `TurnVirtualSocket.QueuedOutgoingFrame` to carry a `releaseCallback` and ensure a one-time `release()` is invoked when an enqueued entry is accepted, rejected, or cleaned up, so the global byte accounting is reclaimed reliably. 
- Add `enqueueOutgoing(..., Runnable releaseCallback)` and `out(..., Runnable releaseCallback)` paths to thread the release callback into the `BlockingPacketQueue` lifecycle (successful enqueue -> release on dequeue completion/error). 
- Add a regression test `testQueuedFrameBytesAreGloballyBounded` that verifies a second queued  frame is rejected when the configured byte budget is exhausted, and update helpers to support payload-bearing test frames.

### Testing
- Ran the TURN server unit tests: `./gradlew :nostr4j-turn-server:test --tests org.ngengine.nostr4j.turn.ref.TestTurnServerInternalRegression --no-daemon`, all targeted internal regression tests passed. 
- Exercised selective compliance tests: `./gradlew :nostr4j-turn-server:test --tests org.ngengine.nostr4j.turn.ref.TestTurnServerCompliance.testDisconnectTeardownRetiresReciprocalSockets --tests org.ngengine.nostr4j.turn.ref.TestTurnServerCompliance.testDuplicateLogicalIdentityLastConnectWins --no-daemon`, which passed after a transient retry of an initially flaky run. 
- Ran the entire `:nostr4j-turn-server:test` suite; the build completed successfully (`BUILD SUCCESSFUL`) after addressing initial flaky behavior during the iterative validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fecbdf7c78832e83b2df43666173e4)